### PR TITLE
Implement new fee claiming mechanics

### DIFF
--- a/contracts/DelphiVoting.sol
+++ b/contracts/DelphiVoting.sol
@@ -3,25 +3,38 @@ pragma solidity ^0.4.18;
 import "tcr/Registry.sol";
 import "tcr/Parameterizer.sol";
 import "./DelphiStake.sol";
+import "dll/DLL.sol";
+import "./LookupTable.sol";
 
 contract DelphiVoting {
 
-  event VoteCommitted(address voter, bytes32 _claimId);
+  event VoteCommitted(address voter, bytes32 claimId, bytes32 secret);
+  event VoteRevealed(address voter, bytes32 claimId, uint faction);
 
   enum VoteOptions { Justified, NotJustified, Collusive, Fault }
+
+  using AttributeStore for AttributeStore.Data;
+  using DLL for DLL.Data;
+
+  struct Commit {
+    bytes32 commit;
+    uint timestamp;
+  }
 
   struct Claim {
     uint commitEndTime;
     uint revealEndTime;
     VoteOptions result;
+    mapping(uint => DLL.Data) factions;
     mapping(uint => uint) tallies;
-    mapping(address => bytes32) commits;
+    mapping(address => Commit) commits;
     mapping(address => bool) hasRevealed;
     mapping(address => bool) claimedReward;
   }
 
   Registry public arbiterSet;
   Parameterizer public parameterizer;
+  LookupTable public lt;
 
   mapping(bytes32 => Claim) public claims;
 
@@ -30,15 +43,16 @@ contract DelphiVoting {
     _;
   }
 
-  function init(address _arbiterSet, address _parameterizer) public {
+  function init(address _arbiterSet, address _parameterizer, uint _feeDecayValue) public {
     require(_arbiterSet != 0 && arbiterSet == address(0));
     require(_parameterizer != 0 && parameterizer == address(0));
 
     arbiterSet = Registry(_arbiterSet);
     parameterizer = Parameterizer(_parameterizer);
+    lt = new LookupTable(_feeDecayValue);
   }
 
-  /**
+  /*
   @dev Commits a vote for the specified claim. Can be overwritten while commitPeriod is active
   @param _stake the address of a DelphiStake contract
   @param _claimNumber an initialized claim in the provided DelphiStake
@@ -65,23 +79,24 @@ contract DelphiVoting {
     require(commitPeriodActive(claimId));
 
     // Set this voter's commit for this claim to their provided secretHash.
-    claims[claimId].commits[msg.sender] = _secretHash;
+    claims[claimId].commits[msg.sender] = Commit({commit: _secretHash, timestamp: block.number});
 
     // Fire an event saying the message sender voted for this claimID.
     // TODO: Make this event fire the stake and claim number instead of the claimID.
-    VoteCommitted(msg.sender, claimId);
+    emit VoteCommitted(msg.sender, claimId, _secretHash);
   }
 
-  /**
+  /*
   @dev Reveals a vote for the specified claim.
   @param _claimId the keccak256 of a DelphiStake address and a claim number for which the message
   sender has previously committed a vote
   @param _vote the option voted for in the original secret hash.
   @param _salt the salt concatenated to the vote option when originally hashed to its secret form
+  @param _previousCommitter the node in the faction's DLL for this claim which should come before
+  the one we will insert here. Can be computed using getInsertPoint.
   */
-  function revealVote(bytes32 _claimId, uint _vote, uint _salt)
+  function revealVote(bytes32 _claimId, uint _vote, uint _salt, address _previousCommitter)
   public onlyArbiters(msg.sender) {
-    VoteOptions vote = VoteOptions(_vote);
     Claim storage claim = claims[_claimId];
 
     // Do not allow revealing while the reveal period is not active
@@ -89,27 +104,103 @@ contract DelphiVoting {
     // Do not allow a voter to reveal more than once
     require(!claim.hasRevealed[msg.sender]);
     // Require the provided vote is consistent with the original commit
-    require(keccak256(_vote, _salt) == claims[_claimId].commits[msg.sender]);
+    require(keccak256(_vote, _salt) == claims[_claimId].commits[msg.sender].commit);
 
-    // Tally the vote
-    if(vote == VoteOptions.Justified) {
-      claim.tallies[uint(VoteOptions.Justified)] += 1;
-    }
-    else if(vote == VoteOptions.NotJustified) {
-      claim.tallies[uint(VoteOptions.NotJustified)] += 1;
-    }
-    else if(vote == VoteOptions.Collusive) {
-      claim.tallies[uint(VoteOptions.Collusive)] += 1;
-    }
-    else if(vote == VoteOptions.Fault) {
-      claim.tallies[uint(VoteOptions.Fault)] += 1;
-    }
+    // We need the nodes on either side of the node we are proposing to insert, so grab the
+    // next node of the provided previous node. Once we have these, check if the insertion point
+    // is valid with the validPosition function.
+    address nextCommitter =
+      address(claim.factions[_vote].getNext(uint(_previousCommitter)));
+    require(validPosition(_previousCommitter, nextCommitter, _claimId, _vote));
+
+    // Insert the voter into their faction's list, and increment the tally for that vote option
+    claim.factions[_vote].insert(uint(_previousCommitter),
+                                uint(msg.sender),
+                                uint(nextCommitter));
+    claim.tallies[_vote]++;
 
     // Set hasRevealed to true so this voter cannot reveal again
     claim.hasRevealed[msg.sender] = true;
+
+
+    emit VoteRevealed(msg.sender, _claimId, _vote);
   }
 
-  /**
+  /*
+  @dev prevents a user from inserting themselves ahead of other arbiters improperly by checking
+  when they committed their faction vote, and then making sure the arbiter they propose to come
+  after committed earlier, and the arbiter they propose to come before committed later.
+  @param _previousCommitter an arbiter in the same faction who committed before the msg.sender
+  @param _nextCommitter an arbiter in the same faction who committed after the msg.sender
+  @param _claimId the claim whose factions are being inspected.
+  @param _faction the faction in this claim where we make the insertion
+  @return bool asserting whether the proposed insert point is valid or not
+  */
+  function validPosition(address _previousCommitter, address _nextCommitter, bytes32 _claimId,
+                         uint _faction)
+  public view returns (bool) {
+    Claim storage claim = claims[_claimId];
+
+    // Assert the provided arbiters are all in the same faction (or that we are inserting into the
+    // beginning, end of, or into an empty, list.
+    require((claim.factions[_faction].contains(uint(_previousCommitter)) ||
+             uint(_previousCommitter) == 0) &&
+             (claim.factions[_faction].contains(uint(_nextCommitter)) ||
+             uint(_nextCommitter) == 0));
+
+    // Assert that the proposed insertion point is between two adjacent nodes
+    require(claim.factions[_faction].getNext(uint(_previousCommitter)) == uint(_nextCommitter));
+
+    // Get timestamps for when all of the involved arbiters made their commits
+    uint timestamp = claim.commits[msg.sender].timestamp;
+    uint prevTimestamp = claim.commits[_previousCommitter].timestamp;
+    uint nextTimestamp = claim.commits[_nextCommitter].timestamp;
+
+    // If the committer committed later than the specified previous committer and earlier than
+    // the specified next committer, return true. Else false.
+    if((prevTimestamp <= timestamp) && ((timestamp <= nextTimestamp) || _nextCommitter == 0)) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /*
+  @dev computes the _previousCommitter argument required by the revealVote function
+  @param _claimId the claim a vote is being revealed for
+  @param _committer a committer in the claim being revealed for
+  @param _faction the faction of a committer in the claim being revealed for
+  @return address the committer (or insert point) the provided committer should insert after
+  */
+  function getInsertPoint(bytes32 _claimId, address _committer, uint _faction)
+  public view returns (address) {
+    Claim storage claim = claims[_claimId];
+
+    uint timestamp = claim.commits[_committer].timestamp;
+    DLL.Data storage faction = claim.factions[_faction];
+
+    // In this loop, we will iterate over the list until we find an insertion point for our node.
+    // When the currentNode is zero, we have reached the end of the list (or the list was empty
+    // to start).
+    uint currentNode = faction.getStart();
+    while(currentNode != 0) {
+      uint nextNode = faction.getNext(currentNode);
+      // Check whether the committer's timestamp is >= the current committer's && <= the next
+      // committer's (or we are inserting at the end of the list)
+      if((claim.commits[address(currentNode)].timestamp <= timestamp) &&
+        ((timestamp <= claim.commits[address(nextNode)].timestamp) ||
+        nextNode == 0)) {
+        return address(currentNode);
+      }
+      currentNode = nextNode;
+    }
+
+    // If we reach the end of the list, either the list was empty or our insertion point is at
+    // the very beginning.
+    return address(0);
+  }
+
+  /*
   @dev Submits a ruling to a DelphiStake contract
   @param _stake address of a DelphiStake contract
   @param _claimNumber nonce of a unique claim for the provided stake
@@ -131,7 +222,7 @@ contract DelphiVoting {
     ds.ruleOnClaim(_claimNumber, uint256(claim.result));
   }
 
-  /**
+  /*
   @dev allow an arbiter who participated in the plurality voting bloc to claim their share of the
   fee
   @param _stake address of a DelphiStake contract
@@ -150,7 +241,7 @@ contract DelphiVoting {
     // Do not allow arbiters to claim rewards for a claim more than once
     require(!claim.claimedReward[msg.sender]);
     // Check that the arbiter actually committed the vote they say they did
-    require(keccak256(_vote, _salt) == claim.commits[msg.sender]);
+    require(keccak256(_vote, _salt) == claim.commits[msg.sender].commit);
     // Require the vote cast was in the plurality
     require(VoteOptions(_vote) == claim.result);
 
@@ -163,7 +254,7 @@ contract DelphiVoting {
     claim.claimedReward[msg.sender] = true;
   }
 
-  /**
+  /*
   @dev Checks if the commit period is still active for the specified claim
   @param _claimId Integer identifier associated with target claim
   @return bool indicating whetherh the commit period is active for this claim
@@ -174,7 +265,7 @@ contract DelphiVoting {
       return (block.timestamp < claims[_claimId].commitEndTime);
   }
 
-  /**
+  /*
   @dev Checks if the reveal period is still active for the specified claim
   @param _claimId the keccak256 of a DelphiStake address and a claim number
   @return bool indicating whetherh the reveal period is active for this claim
@@ -186,7 +277,7 @@ contract DelphiVoting {
         ((!commitPeriodActive(_claimId)) && (block.timestamp < claims[_claimId].revealEndTime));
   }
 
-  /**
+  /*
   @dev Checks if a claim exists, throws if the provided claim is in an impossible state
   @param _claimId the keccak256 of a DelphiStake address and a claim number
   @return Boolean Indicates whether a claim exists for the provided claimId
@@ -204,17 +295,17 @@ contract DelphiVoting {
     return true;
   }
 
-  /**
+  /*
   @dev returns the commit hash of the provided arbiter for some claim
   @param _claimId the keccak256 of a DelphiStake address and a claim number
   @return bytes32 the arbiter's commit hash for this claim
   */
   function getArbiterCommitForClaim(bytes32 _claimId, address _arbiter)
   view public returns (bytes32) {
-    return claims[_claimId].commits[_arbiter];
+    return claims[_claimId].commits[_arbiter].commit;
   }
 
-  /**
+  /*
   @dev Returns the number of revealed votes for the provided vote option in a given claim
   @param _claimId the keccak256 of a DelphiStake address and a claim number
   @param _option The vote option to return a total for
@@ -243,7 +334,7 @@ contract DelphiVoting {
     return ruled;
   }
 
-  /**
+  /*
   @dev Initialize a claim struct by setting its commit and reveal end times
   @param _claimId the keccak256 of a DelphiStake address and a claim number
   */
@@ -253,7 +344,7 @@ contract DelphiVoting {
       claims[_claimId].commitEndTime + parameterizer.get('revealStageLen');
   }
 
-  /**
+  /*
   @dev Updates the winning option in the claim to that with the greatest number of votes
   @param _claim storage pointer to a Claim struct
   */

--- a/contracts/DelphiVotingFactory.sol
+++ b/contracts/DelphiVotingFactory.sol
@@ -26,14 +26,15 @@ contract DelphiVotingFactory {
   supplied by the user.
   @param _token an EIP20 token to be consumed by the new PLCR contract
   */
-  function makeDelphiVoting(address _arbiterSet, bytes32[] _paramKeys, uint[] _paramValues)
+  function makeDelphiVoting(address _arbiterSet, uint _feeDecayValue, bytes32[] _paramKeys,
+                            uint[] _paramValues)
   public returns (DelphiVoting dv) {
     address parameterizer = parameterizerFactory.createDemocraticParameterizer(
       _arbiterSet, _paramKeys, _paramValues
     );
 
     dv = DelphiVoting(proxyFactory.createProxy(canonizedDelphiVoting, ""));
-    dv.init(_arbiterSet, parameterizer);
+    dv.init(_arbiterSet, parameterizer, _feeDecayValue);
 
     emit newDelphiVoting(msg.sender, dv, _arbiterSet, parameterizer);
   }

--- a/contracts/LookupTable.sol
+++ b/contracts/LookupTable.sol
@@ -1,0 +1,56 @@
+pragma solidity ^0.4.18;
+
+contract LookupTable {
+  // lt is the lookup table. The value at index i is the total percentage of the fee which will
+  // have been allocated for all arbiters 0..i. As a user, you probably do not want to call this
+  // directly. getGuaranteedPercentageForIndex is probably what you want.
+  uint[] public lt;
+  // computed is the number of values computed for the lookup table so far.
+  uint public computed;
+  // decayValue is a magic number used to compute values in the lookup table.
+  uint public decayValue;
+
+  constructor(uint _decayValue) public {
+    decayValue = _decayValue;
+    lt.push(100 / decayValue);
+    computed = 0;
+  }
+
+  /*
+  @dev computes the percentage of a fee an arbiter is owed
+  @param _index the zero-indexed order in which an arbiter committed a vote to the plurality set
+  @return the percentage of a fee the arbiter at the given index is owed
+  */
+  function getGuaranteedPercentageForIndex(uint _index) public returns (uint) {
+    // If the value at this index is not available, compute it.
+    uint lti = computeLookupTableValues(_index);
+
+    if(_index == 0) {
+      return lti;
+    } else {
+      return lti - lt[_index - 1];
+    }
+  }
+
+  /*
+  @dev recursive function computes lookup table values. Does nothing if a value is already stored
+  at the provided index.
+  @param _index the lookup table index to compute a value for
+  @return the total percentage of a fee which will have been allocated for all arbiter 0..i.
+  */
+  function computeLookupTableValues(uint _index) internal returns (uint) {
+    // If we have not computed a value for this index yet, compute it.
+    if(_index > computed) {
+      // Computing i always requires the value of i - 1.
+      uint previousLTValue = computeLookupTableValues(_index - 1);
+
+      // Compute i and append it to the end of the lookupTable
+      lt.push(((100 - previousLTValue) / decayValue) + previousLTValue);
+      computed++;
+    }
+
+    // Return the value in the lookup table at the provided index.
+    return lt[_index];
+  }
+}
+

--- a/ethpm.json
+++ b/ethpm.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "tokens": "1.0.0",
     "tcr": "1.1.0",
-    "democratic-parameterizer": "2.0.0"
+    "democratic-parameterizer": "2.0.0",
+    "dll": "1.0.4"
   },
   "license": "Apache 2.0"
 }

--- a/migrations/4_delphivoting_factory.js
+++ b/migrations/4_delphivoting_factory.js
@@ -3,7 +3,13 @@
 const DelphiVotingFactory = artifacts.require('DelphiVotingFactory.sol');
 const DemocraticParameterizerFactory =
   artifacts.require('democratic-parameterizer/DemocraticParameterizerFactory.sol');
+const DLL = artifacts.require('dll/DLL.sol');
 
-module.exports = deployer => deployer.deploy(DemocraticParameterizerFactory)
-  .then(() => deployer.deploy(DelphiVotingFactory, DemocraticParameterizerFactory.address));
+module.exports = (deployer) => {
+  deployer.deploy(DLL);
+  deployer.link(DLL, DelphiVotingFactory);
+
+  return deployer.deploy(DemocraticParameterizerFactory)
+    .then(() => deployer.deploy(DelphiVotingFactory, DemocraticParameterizerFactory.address));
+};
 

--- a/test/js/DelphiVoting/claimFee.js
+++ b/test/js/DelphiVoting/claimFee.js
@@ -68,10 +68,10 @@ contract('DelphiVoting', (accounts) => {
       await registry.updateStatus(solkeccak(arbiterBob));
       await registry.updateStatus(solkeccak(arbiterCharlie));
 
-      // Create a DelphiVoting with 100 second voting periods, and which uses the registry we
-      // just created as its arbiter set
+      // Create a DelphiVoting with 100 second voting periods, fee decay value of five, 
+      // and which uses the registry we just created as its arbiter set
       const delphiVotingReceipt = await delphiVotingFactory.makeDelphiVoting(registry.address,
-        [solkeccak('parameterizerVotingPeriod'), solkeccak('commitStageLen'),
+        5, [solkeccak('parameterizerVotingPeriod'), solkeccak('commitStageLen'),
           solkeccak('revealStageLen')],
         [100, 100, 100]);
       delphiVoting = DelphiVoting.at(delphiVotingReceipt.logs[0].args.delphiVoting);
@@ -114,7 +114,8 @@ contract('DelphiVoting', (accounts) => {
       await rpc.sendAsync({ method: 'evm_increaseTime', params: [101] });
 
       // Reveal vote
-      await delphiVoting.revealVote(claimId, VOTE, SALT, { from: arbiterAlice });
+      const insertPoint = await delphiVoting.getInsertPoint.call(claimId, arbiterAlice, VOTE);
+      await delphiVoting.revealVote(claimId, VOTE, SALT, insertPoint, { from: arbiterAlice });
 
       // Increase time to finish the reveal phase so we can submit
       await rpc.sendAsync({ method: 'evm_increaseTime', params: [100] });
@@ -158,7 +159,8 @@ contract('DelphiVoting', (accounts) => {
       await rpc.sendAsync({ method: 'evm_increaseTime', params: [101] });
 
       // Reveal vote
-      await delphiVoting.revealVote(claimId, VOTE, SALT, { from: arbiterAlice });
+      const insertPoint = await delphiVoting.getInsertPoint.call(claimId, arbiterAlice, VOTE);
+      await delphiVoting.revealVote(claimId, VOTE, SALT, insertPoint, { from: arbiterAlice });
 
       // Increase time to finish the reveal phase so we can submit
       await rpc.sendAsync({ method: 'evm_increaseTime', params: [100] });
@@ -217,9 +219,18 @@ contract('DelphiVoting', (accounts) => {
         await rpc.sendAsync({ method: 'evm_increaseTime', params: [101] });
 
         // Arbiters reveal votes
-        await delphiVoting.revealVote(claimId, PLURALITY_VOTE, SALT, { from: arbiterAlice });
-        await delphiVoting.revealVote(claimId, PLURALITY_VOTE, SALT, { from: arbiterBob });
-        await delphiVoting.revealVote(claimId, NON_PLURALITY_VOTE, SALT, { from: arbiterCharlie });
+        const insertPointAlice =
+          await delphiVoting.getInsertPoint.call(claimId, arbiterAlice, PLURALITY_VOTE);
+        await delphiVoting.revealVote(claimId, PLURALITY_VOTE, SALT, insertPointAlice,
+          { from: arbiterAlice });
+        const insertPointBob =
+          await delphiVoting.getInsertPoint.call(claimId, arbiterAlice, PLURALITY_VOTE);
+        await delphiVoting.revealVote(claimId, PLURALITY_VOTE, SALT, insertPointBob,
+          { from: arbiterBob });
+        const insertPointCharlie =
+          await delphiVoting.getInsertPoint.call(claimId, arbiterAlice, NON_PLURALITY_VOTE);
+        await delphiVoting.revealVote(claimId, NON_PLURALITY_VOTE, SALT, insertPointCharlie,
+          { from: arbiterCharlie });
 
         // Increase time to finish the reveal phase so we can submit the ruling
         await rpc.sendAsync({ method: 'evm_increaseTime', params: [100] });
@@ -273,8 +284,14 @@ contract('DelphiVoting', (accounts) => {
       await rpc.sendAsync({ method: 'evm_increaseTime', params: [101] });
 
       // Arbiters reveal votes
-      await delphiVoting.revealVote(claimId, PLURALITY_VOTE, SALT, { from: arbiterAlice });
-      await delphiVoting.revealVote(claimId, PLURALITY_VOTE, SALT, { from: arbiterBob });
+      const insertPointAlice =
+        await delphiVoting.getInsertPoint.call(claimId, arbiterAlice, PLURALITY_VOTE);
+      await delphiVoting.revealVote(claimId, PLURALITY_VOTE, SALT, insertPointAlice,
+        { from: arbiterAlice });
+      const insertPointBob =
+        await delphiVoting.getInsertPoint.call(claimId, arbiterAlice, PLURALITY_VOTE);
+      await delphiVoting.revealVote(claimId, PLURALITY_VOTE, SALT, insertPointBob,
+        { from: arbiterBob });
 
       // Increase time to finish the reveal phase so we can submit the ruling
       await rpc.sendAsync({ method: 'evm_increaseTime', params: [100] });
@@ -333,7 +350,8 @@ contract('DelphiVoting', (accounts) => {
       await rpc.sendAsync({ method: 'evm_increaseTime', params: [101] });
 
       // Reveal vote
-      await delphiVoting.revealVote(claimId, VOTE, SALT, { from: arbiterAlice });
+      const insertPoint = await delphiVoting.getInsertPoint.call(claimId, arbiterAlice, VOTE);
+      await delphiVoting.revealVote(claimId, VOTE, SALT, insertPoint, { from: arbiterAlice });
 
       // Increase time to finish the reveal phase so we can submit
       await rpc.sendAsync({ method: 'evm_increaseTime', params: [100] });
@@ -377,7 +395,8 @@ contract('DelphiVoting', (accounts) => {
       await rpc.sendAsync({ method: 'evm_increaseTime', params: [101] });
 
       // Reveal vote
-      await delphiVoting.revealVote(claimId, VOTE, SALT, { from: arbiterAlice });
+      const insertPoint = await delphiVoting.getInsertPoint.call(claimId, arbiterAlice, VOTE);
+      await delphiVoting.revealVote(claimId, VOTE, SALT, insertPoint, { from: arbiterAlice });
 
       // Increase time to finish the reveal phase so we can submit
       await rpc.sendAsync({ method: 'evm_increaseTime', params: [100] });

--- a/test/js/DelphiVoting/commitVote.js
+++ b/test/js/DelphiVoting/commitVote.js
@@ -67,10 +67,10 @@ contract('DelphiVoting', (accounts) => {
       await registry.updateStatus(solkeccak(arbiterBob));
       await registry.updateStatus(solkeccak(arbiterCharlie));
 
-      // Create a DelphiVoting with 100 second voting periods, and which uses the registry we
-      // just created as its arbiter set
+      // Create a DelphiVoting with 100 second voting periods, fee decay value of five, 
+      // and which uses the registry we just created as its arbiter set
       const delphiVotingReceipt = await delphiVotingFactory.makeDelphiVoting(registry.address,
-        [solkeccak('parameterizerVotingPeriod'), solkeccak('commitStageLen'),
+        5, [solkeccak('parameterizerVotingPeriod'), solkeccak('commitStageLen'),
           solkeccak('revealStageLen')],
         [100, 100, 100]);
       delphiVoting = DelphiVoting.at(delphiVotingReceipt.logs[0].args.delphiVoting);

--- a/test/js/DelphiVoting/revealVote.js
+++ b/test/js/DelphiVoting/revealVote.js
@@ -67,10 +67,10 @@ contract('DelphiVoting', (accounts) => {
       await registry.updateStatus(solkeccak(arbiterBob));
       await registry.updateStatus(solkeccak(arbiterCharlie));
 
-      // Create a DelphiVoting with 100 second voting periods, and which uses the registry we
-      // just created as its arbiter set
+      // Create a DelphiVoting with 100 second voting periods, fee decay value of five, 
+      // and which uses the registry we just created as its arbiter set
       const delphiVotingReceipt = await delphiVotingFactory.makeDelphiVoting(registry.address,
-        [solkeccak('parameterizerVotingPeriod'), solkeccak('commitStageLen'),
+        5, [solkeccak('parameterizerVotingPeriod'), solkeccak('commitStageLen'),
           solkeccak('revealStageLen')],
         [100, 100, 100]);
       delphiVoting = DelphiVoting.at(delphiVotingReceipt.logs[0].args.delphiVoting);
@@ -117,7 +117,8 @@ contract('DelphiVoting', (accounts) => {
         'the initial vote tally was not as-expected');
 
       // Reveal the arbiter's vote
-      await delphiVoting.revealVote(claimId, VOTE, SALT, { from: arbiterAlice });
+      const insertPoint = await delphiVoting.getInsertPoint.call(claimId, arbiterAlice, VOTE);
+      await delphiVoting.revealVote(claimId, VOTE, SALT, insertPoint, { from: arbiterAlice });
 
       // The final tally for the option we revealed for should be one.
       const finalTally = (await delphiVoting.revealedVotesForOption.call(claimId, VOTE));
@@ -147,10 +148,11 @@ contract('DelphiVoting', (accounts) => {
       await rpc.sendAsync({ method: 'evm_increaseTime', params: [101] });
 
       // Reveal the arbiter's vote
-      await delphiVoting.revealVote(claimId, VOTE, SALT, { from: arbiterAlice });
+      const insertPoint = await delphiVoting.getInsertPoint.call(claimId, arbiterAlice, VOTE);
+      await delphiVoting.revealVote(claimId, VOTE, SALT, insertPoint, { from: arbiterAlice });
 
       try {
-        await delphiVoting.revealVote(claimId, VOTE, SALT, { from: arbiterAlice });
+        await delphiVoting.revealVote(claimId, VOTE, SALT, insertPoint, { from: arbiterAlice });
       } catch (err) {
         assert(utils.isEVMRevert(err), err.toString());
 
@@ -182,7 +184,8 @@ contract('DelphiVoting', (accounts) => {
       await rpc.sendAsync({ method: 'evm_increaseTime', params: [101] });
 
       try {
-        await delphiVoting.revealVote(claimId, VOTE, 421, { from: arbiterAlice });
+        const insertPoint = await delphiVoting.getInsertPoint.call(claimId, arbiterAlice, VOTE);
+        await delphiVoting.revealVote(claimId, VOTE, 421, insertPoint, { from: arbiterAlice });
       } catch (err) {
         assert(utils.isEVMRevert(err), err.toString());
 
@@ -211,7 +214,8 @@ contract('DelphiVoting', (accounts) => {
         { from: arbiterAlice });
 
       try {
-        await delphiVoting.revealVote(claimId, VOTE, SALT, { from: arbiterAlice });
+        const insertPoint = await delphiVoting.getInsertPoint.call(claimId, arbiterAlice, VOTE);
+        await delphiVoting.revealVote(claimId, VOTE, SALT, insertPoint, { from: arbiterAlice });
       } catch (err) {
         assert(utils.isEVMRevert(err), err.toString());
 
@@ -243,7 +247,8 @@ contract('DelphiVoting', (accounts) => {
       await rpc.sendAsync({ method: 'evm_increaseTime', params: [201] });
 
       try {
-        await delphiVoting.revealVote(claimId, VOTE, SALT, { from: arbiterAlice });
+        const insertPoint = await delphiVoting.getInsertPoint.call(claimId, arbiterAlice, VOTE);
+        await delphiVoting.revealVote(claimId, VOTE, SALT, insertPoint, { from: arbiterAlice });
       } catch (err) {
         assert(utils.isEVMRevert(err), err.toString());
 

--- a/test/js/DelphiVoting/submitRuling.js
+++ b/test/js/DelphiVoting/submitRuling.js
@@ -67,10 +67,10 @@ contract('DelphiVoting', (accounts) => { //eslint-disable-line
       await registry.updateStatus(solkeccak(arbiterBob));
       await registry.updateStatus(solkeccak(arbiterCharlie));
 
-      // Create a DelphiVoting with 100 second voting periods, and which uses the registry we
-      // just created as its arbiter set
+      // Create a DelphiVoting with 100 second voting periods, fee decay value of five, 
+      // and which uses the registry we just created as its arbiter set
       const delphiVotingReceipt = await delphiVotingFactory.makeDelphiVoting(registry.address,
-        [solkeccak('parameterizerVotingPeriod'), solkeccak('commitStageLen'),
+        5, [solkeccak('parameterizerVotingPeriod'), solkeccak('commitStageLen'),
           solkeccak('revealStageLen')],
         [100, 100, 100]);
       delphiVoting = DelphiVoting.at(delphiVotingReceipt.logs[0].args.delphiVoting);
@@ -224,7 +224,8 @@ contract('DelphiVoting', (accounts) => { //eslint-disable-line
       await rpc.sendAsync({ method: 'evm_increaseTime', params: [101] });
 
       // Reveal vote
-      await delphiVoting.revealVote(claimId, VOTE, SALT, { from: arbiterAlice });
+      const insertPoint = await delphiVoting.getInsertPoint.call(claimId, arbiterAlice, VOTE);
+      await delphiVoting.revealVote(claimId, VOTE, SALT, insertPoint, { from: arbiterAlice });
 
       // Increase time past reveal period
       await rpc.sendAsync({ method: 'evm_increaseTime', params: [100] });
@@ -259,7 +260,8 @@ contract('DelphiVoting', (accounts) => { //eslint-disable-line
         await rpc.sendAsync({ method: 'evm_increaseTime', params: [101] });
 
         // Reveal vote
-        await delphiVoting.revealVote(claimId, VOTE, SALT, { from: arbiterAlice });
+        const insertPoint = await delphiVoting.getInsertPoint.call(claimId, arbiterAlice, VOTE);
+        await delphiVoting.revealVote(claimId, VOTE, SALT, insertPoint, { from: arbiterAlice });
 
         // Increase time past reveal period
         await rpc.sendAsync({ method: 'evm_increaseTime', params: [100] });

--- a/test/js/DelphiVotingFactory/makeDelphiVoting.js
+++ b/test/js/DelphiVotingFactory/makeDelphiVoting.js
@@ -19,8 +19,8 @@ contract('DelphiVotingFactory', () => {
     });
 
     it('should deploy a new DelphiVoting contract with a 100 second voting period', async () => {
-      const receipt = await dvf.makeDelphiVoting(2666, [solkeccak('parameterizerVotingPeriod')],
-        [100]);
+      const receipt = await dvf.makeDelphiVoting(2666, 5,
+        [solkeccak('parameterizerVotingPeriod')], [100]);
       const dv = DelphiVoting.at(receipt.logs[0].args.delphiVoting);
       const dp = DemocraticParameterizer.at(await dv.parameterizer.call());
 


### PR DESCRIPTION
This PR refactors fee claiming in DelphiVoting such that arbiters who commit votes earlier are rewarded more. The payout calculation implemented is:

pay_i = arbiterOwedPercentage * (fee / 100) + ((100 - LT[n - 1]) / n) * (fee / 100)

Where arbiterOwedPercentage is derived using a lookup table (LookupTable.sol) which lazily computes and then stores percentages of fees owed to arbiters for different _decay values_. _Decay values_ are magic numbers set at DelphiVoting initialization time that parameterize the strength of the fee decay function.

LT[n-1] is the total percentage of a fee guaranteed for all participating arbiters, and n is the number of participating arbiters.

In English, arbiters get a guaranteed payout determined by the order in which they committed votes. Any remaining part of the fee not reserved for guaranteed payout is divided evenly over all participating arbiters.


Open TODOs to be addressed in follow-on PRs:
- ~Remove an O(n) operation in `claimFee`.~ https://github.com/Bounties-Network/Delphi/pull/71/commits/cfe1902f15b5ed4c3e12c4a79b365eced7ab9dcc
- Rather than deploying a LookupTable in the DelphiVoting `init`, have the `init` take a LookupTable address and modify the LookupTable to store lookup tables for multiple decay values. Ultimately, any number of DelphiVoting contracts using different decay values should be able to share a single lookup table.